### PR TITLE
Conform to RFC 7622 when parsing JIDs

### DIFF
--- a/src/xmpp/jid.rs
+++ b/src/xmpp/jid.rs
@@ -63,6 +63,7 @@ impl FromStr for Jid {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // TODO: The regex below is not perfect. For example it incorrectly parses <a.example.com/b@example.net>.
         let regex = Regex::new("(?:(?P<local>.+)@)?(?P<domain>.+)(?:/(?P<resource>.+))?").unwrap();
         match regex.captures(s) {
             Some(captures) => {


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc7622 (XMPP addresses)
https://www.rfc-editor.org/rfc/rfc7564 (PRECIS)
https://crates.io/crates/precis-profiles (PRECIS implementation)